### PR TITLE
Remove all function-like uses of array_init

### DIFF
--- a/ogr.c
+++ b/ogr.c
@@ -2980,10 +2980,7 @@ PHP_FUNCTION(ogr_f_getfieldasintegerlist)
         RETURN_NULL();
     }
 
-	if (array_init(return_value) == FAILURE)
-	{
-		RETURN_NULL();
-	}
+	array_init(return_value);
 
     _ZVAL_PTR_DTOR(refncount);
     ZVAL_LONG(refncount, ncount);
@@ -3028,10 +3025,7 @@ PHP_FUNCTION(ogr_f_getfieldasdoublelist)
         RETURN_NULL();
     }
 
-	if (array_init(return_value) == FAILURE)
-	{
-		RETURN_NULL();
-	}
+	array_init(return_value);
 
     _ZVAL_PTR_DTOR(refncount);
     ZVAL_DOUBLE(refncount, ncount);
@@ -3083,10 +3077,7 @@ PHP_FUNCTION(ogr_f_getfieldasstringlist)
         RETURN_NULL();
     }
 
-	if (array_init(return_value) == FAILURE)
-	{
-		RETURN_NULL();
-	}
+	array_init(return_value);
 
 	while (numelements < ncount) {
         _ADD_NEXT_INDEX_STRING(return_value, (char *)


### PR DESCRIPTION
 * From PHP7.3 the array_init-macro is no longer function-like

 * In any case the return type was void and not consistently checked

 * Now consistently just call the macro without trying to check a result

Refs #7