### PR TITLE
Support PHP 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ The code is available under a MIT-style license - see LICENSE. The original lice
 
 ## Supported PHP version
 
-Currently PHP 5 >= 5.4 and PHP 7 are supported. The last version known to support PHP 5 <= 5.3 is tagged as php53 for reference.
+Currently PHP 7 >= 7.3 and PHP 8.0 are supported. It is assumed that the extension will compile and work with older versions, but these are no longer tested.
+
+The last version known to support PHP 5 <= 5.3 is tagged as php53 for reference.
+
+The last version known to support PHP 5.6 and PHP 7 <= 7.2 is tagged as 1.5.1.
 
 ## Why here?
 

--- a/config.m4
+++ b/config.m4
@@ -62,5 +62,4 @@ if test "$PHP_OGR" != "no"; then
   PHP_SUBST(OGR_SHARED_LIBADD)
 
   PHP_NEW_EXTENSION(ogr, ogr.c, $ext_shared)
-  PHP_EXTENSION(ogr, $ext_shared)
 fi

--- a/ogr.c
+++ b/ogr.c
@@ -6,7 +6,7 @@
  *
  ******************************************************************************
  * Copyright (c) 2003, DM Solutions Group Inc
- * Copyright (c) 2019, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
+ * Copyright (c) 2019-2021, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/ogr.c
+++ b/ogr.c
@@ -915,10 +915,8 @@ PHP_FUNCTION(ogr_g_getenvelope)
 
     _ZVAL_PTR_DTOR(oenvel);
 
-    if (object_init(oenvel)==FAILURE) {
-        php_report_ogr_error(E_WARNING);
-        RETURN_FALSE;
-    }
+    OBJECT_INIT(oenvel)
+
 
     add_property_double(oenvel, "minx", oEnvelope.MinX);
     add_property_double(oenvel, "maxx", oEnvelope.MaxX);
@@ -3949,10 +3947,8 @@ PHP_FUNCTION(ogr_l_getextent)
 
     _ZVAL_PTR_DTOR(oextent);
 
-    if (object_init(oextent)==FAILURE) {
-        php_report_ogr_error(E_WARNING);
-        RETURN_FALSE;
-    }
+    OBJECT_INIT(oextent)
+
 
     add_property_double(oextent, "minx", oEnvelope.MinX);
     add_property_double(oextent, "maxx", oEnvelope.MaxX);

--- a/php_ogr.h
+++ b/php_ogr.h
@@ -6,7 +6,7 @@
  *
  ******************************************************************************
  * Copyright (c) 2003, DM Solutions Group Inc
- * Copyright (c) 2019, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
+ * Copyright (c) 2019-2021, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/php_ogr_api.h
+++ b/php_ogr_api.h
@@ -5,7 +5,7 @@
  * Author:   Edward Nash, e.nash@dvz-mv.de
  *
  ******************************************************************************
- * Copyright (c) 2019, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
+ * Copyright (c) 2019-2021, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/php_ogr_shims.h
+++ b/php_ogr_shims.h
@@ -65,7 +65,7 @@
 #define _ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null) \
     ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null)
 /* class_name argument was removed in PHP 7.2 */
-#if PHP_MINOR_VERSION < 2
+#if PHP_MAJOR_VERSION < 8 && PHP_MINOR_VERSION < 2
 #define _ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, arginfo_required_num, type, class_name, allow_null) \
     ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_reference, arginfo_required_num, type, class_name, allow_null)
 #else

--- a/php_ogr_shims.h
+++ b/php_ogr_shims.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Project:  PHP Interface for OGR C API
- * Purpose:  Shims for PHP5 and PHP7 compatibility
+ * Purpose:  Shims for PHP5 and PHP7+ compatibility
  * Author:   Edward Nash, e.nash@dvz-mv.de
  *
  ******************************************************************************
@@ -27,7 +27,7 @@
  */
 
 
-/* Shim macros ZEND_FETCH_RESOURCE and ZEND_FETCH_RESOURCE2 for PHP7 */
+/* Shim macros ZEND_FETCH_RESOURCE and ZEND_FETCH_RESOURCE2 for PHP7+ */
 #if PHP_MAJOR_VERSION < 7
 #define _ZEND_FETCH_RESOURCE(rsrc, rsrc_type, passed_id, default_id, resource_type_name, resource_type) \
     ZEND_FETCH_RESOURCE(rsrc, rsrc_type, &passed_id, default_id, resource_type_name, resource_type)
@@ -42,13 +42,13 @@
    if (rsrc == NULL) RETURN_FALSE;
 #endif
 
-/* Define macro ZEND_REGISTER_RESOURCE for PHP7 */
+/* Define macro ZEND_REGISTER_RESOURCE for PHP7+ */
 #if PHP_MAJOR_VERSION >= 7
 #define ZEND_REGISTER_RESOURCE(zval, rsrc, resource_type) \
     ZVAL_RES(zval, zend_register_resource(rsrc, resource_type));
 #endif
 
-/* Shim function zend_list_delete for PHP7 */
+/* Shim function zend_list_delete for PHP7+ */
 #if PHP_MAJOR_VERSION < 7
 #define _ZEND_FREE_RESOURCE(zv) zend_list_delete(Z_LVAL_P(zv))
 #else
@@ -74,7 +74,7 @@
 #endif
 #endif
 
-/* shim zend_rsrc_list_entry (PHP5) and zend_resource (PHP7) */
+/* shim zend_rsrc_list_entry (PHP5) and zend_resource (PHP7+) */
 #if PHP_MAJOR_VERSION < 7
 typedef zend_rsrc_list_entry zend_resource_t;
 #else

--- a/php_ogr_shims.h
+++ b/php_ogr_shims.h
@@ -156,3 +156,20 @@ typedef size_t strsize_t;
 #else
 #define _ZVAL_PTR_DTOR(__zval) zval_ptr_dtor(__zval)
 #endif
+
+/* shim all thread-safety macros deprecated in PHP7 and removed in PHP8 */
+#ifndef TSRMLS_D
+#define TSRMLS_D void
+#endif
+#ifndef TSRMLS_DC
+#define TSRMLS_DC
+#endif
+#ifndef TSRMLS_C
+#define TSRMLS_C
+#endif
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#endif
+#ifndef TSRMLS_FETCH
+#define TSRMLS_FETCH()
+#endif

--- a/php_ogr_shims.h
+++ b/php_ogr_shims.h
@@ -4,7 +4,7 @@
  * Author:   Edward Nash, e.nash@dvz-mv.de
  *
  ******************************************************************************
- * Copyright (c) 2019, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
+ * Copyright (c) 2019-2021, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/php_ogr_shims.h
+++ b/php_ogr_shims.h
@@ -173,3 +173,13 @@ typedef size_t strsize_t;
 #ifndef TSRMLS_FETCH
 #define TSRMLS_FETCH()
 #endif
+
+/* shim return check on object_init (void in PHP 8) */
+#if PHP_MAJOR_VERSION < 8
+#define OBJECT_INIT(_zval) if (object_init(_zval)==FAILURE) { \
+    php_report_ogr_error(E_WARNING); \
+    RETURN_FALSE; \
+}
+#else
+#define OBJECT_INIT(_zval) object_init(_zval);
+#endif

--- a/stubs/_generator.php
+++ b/stubs/_generator.php
@@ -5,7 +5,7 @@
  * Author:   Edward Nash, e.nash@dvz-mv.de
  *
  ******************************************************************************
- * Copyright (c) 2019, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
+ * Copyright (c) 2019-2021, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/stubs/ogr.php
+++ b/stubs/ogr.php
@@ -5,7 +5,7 @@
  * Author:   Edward Nash, e.nash@dvz-mv.de
  *
  ******************************************************************************
- * Copyright (c) 2019, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
+ * Copyright (c) 2019-2021, DVZ Datenverarbeitungszentrum Mecklenburg-Vorpommern GmbH
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -1399,33 +1399,6 @@ function osr_release($srs)
  * @return int
  */
 function osr_validate($srs)
-{
-}
-
-
-/**
- * @param resource $srs
- * @return int
- */
-function osr_fixupordering($srs)
-{
-}
-
-
-/**
- * @param resource $srs
- * @return int
- */
-function osr_fixup($srs)
-{
-}
-
-
-/**
- * @param resource $srs
- * @return int
- */
-function osr_stripctparms($srs)
 {
 }
 


### PR DESCRIPTION
 * Allows compilation of OGR-extension with PHP 8.0
 * Tested on Debian Bullseye using PHP8 packages from sury.org
 * Compatibility with PHP7.3 (on Debian Buster) tested
 * Compatibility with previously supported older versions of PHP is assumed, but not tested.