### PR TITLE
Update to PHPUnit 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make
 
 This will leave the `ogr.so` file under `modules`. This may be installed and/or made available to PHP by adding the line `extension=path/to/ogr.so` to `php.ini`
 
-PHPUnit (5.7) tests are provided for the API functions. These may be run as
+PHPUnit (9.x) tests are provided for the API functions. These may be run as
 follows:
 
 ```bash

--- a/phpunit_tests/composer.json
+++ b/phpunit_tests/composer.json
@@ -5,8 +5,8 @@
     "type": "project",
     "license": "MIT",
     "require": {
-      "php": "^5.4|^7",
-      "phpunit/phpunit": "^5.7"
+      "php": "^7.3|^8",
+      "phpunit/phpunit": "^9"
     },
     "autoload": {
       "psr-4": {

--- a/phpunit_tests/src/tests/CPLErrorTest0.php
+++ b/phpunit_tests/src/tests/CPLErrorTest0.php
@@ -44,8 +44,7 @@ class CPLErrorTest0 extends TestCase
     {
         @OGR_G_RemoveGeometry($this->hGeometry, 0, true);
         $actual = CPLGetLastErrorNo();
-        $this->assertInternalType(
-            "integer",
+        $this->assertIsInt(
             $actual,
             "CPLGetLastErrorNo should return an integer when there was an error"
         );
@@ -86,8 +85,7 @@ class CPLErrorTest0 extends TestCase
     {
         @OGR_G_RemoveGeometry($this->hGeometry, 0, true);
         $actual = CPLGetLastErrorType();
-        $this->assertInternalType(
-            "integer",
+        $this->assertIsInt(
             $actual,
             "CPLGetLastErrorType should return an integer when there was an error"
         );
@@ -121,8 +119,7 @@ class CPLErrorTest0 extends TestCase
     {
         @OGR_G_RemoveGeometry($this->hGeometry, 0, true);
         $actual = CPLGetLastErrorMsg();
-        $this->assertInternalType(
-            "string",
+        $this->assertIsString(
             $actual,
             "CPLGetLastErrorMsg should return a string when there was an error"
         );

--- a/phpunit_tests/src/tests/CPLErrorTest0.php
+++ b/phpunit_tests/src/tests/CPLErrorTest0.php
@@ -17,7 +17,7 @@ class CPLErrorTest0 extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->hGeometry = OGR_G_CreateGeometry(wkbPolygon);
         $hRing = OGR_G_CreateGeometry(wkbLinearRing);
@@ -32,7 +32,7 @@ class CPLErrorTest0 extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    public function tearDown() : void
     {
         $this->hGeometry = null;
     }

--- a/phpunit_tests/src/tests/CPLErrorTest0.php
+++ b/phpunit_tests/src/tests/CPLErrorTest0.php
@@ -1,11 +1,13 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for CPL error handling functions
  *
  * @author Edward Nash
  */
-class CPLErrorTest0 extends PHPUnit_Framework_TestCase
+class CPLErrorTest0 extends TestCase
 {
     /**
      * @var resource

--- a/phpunit_tests/src/tests/OGRDataSourceTest0.php
+++ b/phpunit_tests/src/tests/OGRDataSourceTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRDataSourceTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRDataSourceTest0 extends TestCase
 {
     public $strPathToData;
     public $strPathToOutputData;

--- a/phpunit_tests/src/tests/OGRDataSourceTest0.php
+++ b/phpunit_tests/src/tests/OGRDataSourceTest0.php
@@ -21,15 +21,15 @@ class OGRDataSourceTest0 extends TestCase
     public $iDriver;
     public $astrOptions;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path('andorra', 'shp');
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -49,9 +49,9 @@ class OGRDataSourceTest0 extends TestCase
         $this->astrOptions = array();
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         delete_directory($this->strPathToOutputData);
         // delete your instance

--- a/phpunit_tests/src/tests/OGRDumpReadableTest0.php
+++ b/phpunit_tests/src/tests/OGRDumpReadableTest0.php
@@ -35,7 +35,7 @@ class OGRDumpReadableTest0 extends TestCase
      */
     protected $outFile;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
         $this->outFile = $this->strPathToOutputData . "dump";
@@ -52,7 +52,7 @@ class OGRDumpReadableTest0 extends TestCase
         OGR_F_SetFieldString($this->hFeature, 0, "foo");
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         delete_directory($this->strPathToOutputData);
         OGR_G_DestroyGeometry($this->hGeometry);

--- a/phpunit_tests/src/tests/OGRDumpReadableTest0.php
+++ b/phpunit_tests/src/tests/OGRDumpReadableTest0.php
@@ -1,11 +1,13 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for OGR_?_DumpReadable() functions
  *
  * @author Edward Nash
  */
-class OGRDumpReadableTest0 extends PHPUnit_Framework_TestCase
+class OGRDumpReadableTest0 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/tests/OGRFeatureDefnTest0.php
+++ b/phpunit_tests/src/tests/OGRFeatureDefnTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureDefnTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureDefnTest0 extends TestCase
 {
     public $hContainer;
 

--- a/phpunit_tests/src/tests/OGRFeatureDefnTest0.php
+++ b/phpunit_tests/src/tests/OGRFeatureDefnTest0.php
@@ -6,11 +6,11 @@ class OGRFeatureDefnTest0 extends TestCase
 {
     public $hContainer;
 
-    public function setUp()
+    public function setUp() : void
     {
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         unset($this->hContainer);
     }

--- a/phpunit_tests/src/tests/OGRFeatureDefnTest1.php
+++ b/phpunit_tests/src/tests/OGRFeatureDefnTest1.php
@@ -7,7 +7,7 @@ class OGRFeatureDefnTest1 extends TestCase
     public $hFieldDefn;
     public $hFeatureDefn;
 
-    public function setUp()
+    public function setUp() : void
     {
         $strName = "Lake";
         $this->hFeatureDefn = OGR_FD_Create($strName);
@@ -23,7 +23,7 @@ class OGRFeatureDefnTest1 extends TestCase
         OGR_FD_AddFieldDefn($this->hFeatureDefn, $this->hFieldDefn);
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         OGR_Fld_Destroy($this->hFieldDefn);
         OGR_FD_Destroy($this->hFeatureDefn);

--- a/phpunit_tests/src/tests/OGRFeatureDefnTest1.php
+++ b/phpunit_tests/src/tests/OGRFeatureDefnTest1.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureDefnTest1 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureDefnTest1 extends TestCase
 {
     public $hFieldDefn;
     public $hFeatureDefn;

--- a/phpunit_tests/src/tests/OGRFeatureTest0.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest0.php
@@ -12,16 +12,16 @@ class OGRFeatureTest0 extends TestCase
     public $strDestDataSource;
     public $strOutputLayer;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -32,9 +32,9 @@ class OGRFeatureTest0 extends TestCase
         $this->strOutputLayer = "OutputLayer";
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         delete_directory($this->strPathToOutputData);
         // delete your instance

--- a/phpunit_tests/src/tests/OGRFeatureTest0.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureTest0 extends TestCase
 {
     public $strPathToData;
     public $strPathToOutputData;

--- a/phpunit_tests/src/tests/OGRFeatureTest1.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest1.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureTest1 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureTest1 extends TestCase
 {
     public $strPathToDumpData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRFeatureTest1.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest1.php
@@ -16,13 +16,13 @@ class OGRFeatureTest1 extends TestCase
     public $eGeometryType;
     public $strDestDataSource;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -50,7 +50,7 @@ class OGRFeatureTest1 extends TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         OGR_DS_Destroy($this->hDS);
 

--- a/phpunit_tests/src/tests/OGRFeatureTest2.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest2.php
@@ -15,13 +15,13 @@ class OGRFeatureTest2 extends TestCase
     public $strOutputLayer;
     public $eGeometryType;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -48,7 +48,7 @@ class OGRFeatureTest2 extends TestCase
         $this->eGeometryType = wkbPoint;
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         OGR_DS_Destroy($this->hDS);
 

--- a/phpunit_tests/src/tests/OGRFeatureTest2.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest2.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureTest2 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureTest2 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRFeatureTest3.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest3.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureTest3 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureTest3 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRFeatureTest3.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest3.php
@@ -14,13 +14,13 @@ class OGRFeatureTest3 extends TestCase
     public $hOGRSFDriver;
     public $astrOptions;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -45,7 +45,7 @@ class OGRFeatureTest3 extends TestCase
         $this->assertNotNull($this->hDestLayer);
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         delete_directory($this->strPathToOutputData);
         OGR_DS_Destroy($this->hDestDS);

--- a/phpunit_tests/src/tests/OGRFeatureTest4.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest4.php
@@ -12,12 +12,12 @@ class OGRFeatureTest4 extends TestCase
     public $hLayer;
     public $strDestDataSource;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "mif", "gis_osm_buildings_a_free_1.mif");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -26,7 +26,7 @@ class OGRFeatureTest4 extends TestCase
         $this->strDestDataSource = "OutputDS";
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         delete_directory($this->strPathToOutputData);
         unset($this->strPathToData);

--- a/phpunit_tests/src/tests/OGRFeatureTest4.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest4.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureTest4 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureTest4 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRFeatureTest6.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest6.php
@@ -14,12 +14,12 @@ class OGRFeatureTest6 extends TestCase
     public $hOGRSFDriver;
     public $astrOptions;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -51,7 +51,7 @@ class OGRFeatureTest6 extends TestCase
         $this->assertNotNull($this->hDestLayer, "Unable to create layer");
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         delete_directory($this->strPathToOutputData);
         OGR_DS_Destroy($this->hDestDS);

--- a/phpunit_tests/src/tests/OGRFeatureTest6.php
+++ b/phpunit_tests/src/tests/OGRFeatureTest6.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFeatureTest6 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFeatureTest6 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRFieldDefnTest0.php
+++ b/phpunit_tests/src/tests/OGRFieldDefnTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRFieldDefnTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRFieldDefnTest0 extends TestCase
 {
     public function setUp()
     {

--- a/phpunit_tests/src/tests/OGRFieldDefnTest0.php
+++ b/phpunit_tests/src/tests/OGRFieldDefnTest0.php
@@ -4,11 +4,11 @@ use \PHPUnit\Framework\TestCase;
 
 class OGRFieldDefnTest0 extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
     }
 

--- a/phpunit_tests/src/tests/OGRGeometryTest0.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest0.php
@@ -4,11 +4,11 @@ use \PHPUnit\Framework\TestCase;
 
 class OGRGeometryTest0 extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
     }
 

--- a/phpunit_tests/src/tests/OGRGeometryTest0.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRGeometryTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRGeometryTest0 extends TestCase
 {
     public function setUp()
     {

--- a/phpunit_tests/src/tests/OGRGeometryTest1.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest1.php
@@ -15,12 +15,12 @@ class OGRGeometryTest1 extends TestCase
     public $hRing1;
     public $hRing2;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
-    public function setUp()
+    public function setUp() : void
     {
 
         /*Prepare to write temporary data for comparison.*/
@@ -74,7 +74,7 @@ class OGRGeometryTest1 extends TestCase
         $this->assertEquals($eErr, OGRERR_NONE, "Could not add inner ring to polygon");
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         OGR_G_DestroyGeometry($this->hRing1);
         OGR_G_DestroyGeometry($this->hRing2);

--- a/phpunit_tests/src/tests/OGRGeometryTest1.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest1.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRGeometryTest1 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRGeometryTest1 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRGeometryTest2.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest2.php
@@ -16,12 +16,12 @@ class OGRGeometryTest2 extends TestCase
     public $strOutputLayer;
     public $eGeometryType;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
-    public function setUp()
+    public function setUp() : void
     {
         /*Create a polygon.*/
         $eType = wkbPolygon;
@@ -60,7 +60,7 @@ class OGRGeometryTest2 extends TestCase
         $this->eGeometryType = wkbPolygon;
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         OGR_G_DestroyGeometry($this->hRing1);
         OGR_G_DestroyGeometry($this->hRing2);

--- a/phpunit_tests/src/tests/OGRGeometryTest2.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest2.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRGeometryTest2 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRGeometryTest2 extends TestCase
 {
     public $hContainer;
     public $hRing1;

--- a/phpunit_tests/src/tests/OGRGeometryTest3.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest3.php
@@ -37,7 +37,7 @@ class OGRGeometryTest3 extends TestCase
     /**
      * {@inheritdoc}
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         static::$hRefGeometry = OGR_G_CreateGeometry(wkbPoint25D);
         OGR_G_AddPoint(static::$hRefGeometry, 10, 20, 0.0);

--- a/phpunit_tests/src/tests/OGRGeometryTest3.php
+++ b/phpunit_tests/src/tests/OGRGeometryTest3.php
@@ -1,11 +1,13 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for WKB and WKT import/export functions
  *
  * @author Edward Nash
  */
-class OGRGeometryTest3 extends PHPUnit_Framework_TestCase
+class OGRGeometryTest3 extends TestCase
 {
     /**
      * WKT representation of test geometry

--- a/phpunit_tests/src/tests/OGRLayerTest0.php
+++ b/phpunit_tests/src/tests/OGRLayerTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRLayerTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRLayerTest0 extends TestCase
 {
     public $strPathToData;
     public $strPathToOutputData;

--- a/phpunit_tests/src/tests/OGRLayerTest0.php
+++ b/phpunit_tests/src/tests/OGRLayerTest0.php
@@ -12,16 +12,16 @@ class OGRLayerTest0 extends TestCase
     public $hLayer;
     public $hSrcDataSource;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->bUpdate = false;
@@ -56,9 +56,9 @@ class OGRLayerTest0 extends TestCase
         );
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         OGR_DS_Destroy($this->hSrcDataSource);

--- a/phpunit_tests/src/tests/OGRLayerTest1.php
+++ b/phpunit_tests/src/tests/OGRLayerTest1.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRLayerTest1 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRLayerTest1 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRLayerTest1.php
+++ b/phpunit_tests/src/tests/OGRLayerTest1.php
@@ -14,15 +14,15 @@ class OGRLayerTest1 extends TestCase
     public $hSrcDataSource;
     public $iSpatialFilter;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
         $this->strTmpDumpFile = "DumpFile.tmp";
@@ -56,9 +56,9 @@ class OGRLayerTest1 extends TestCase
         $this->assertNotNull($this->hLayer, "Could not open source layer");
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         OGR_DS_Destroy($this->hSrcDataSource);

--- a/phpunit_tests/src/tests/OGRLayerTest2.php
+++ b/phpunit_tests/src/tests/OGRLayerTest2.php
@@ -15,15 +15,15 @@ class OGRLayerTest2 extends TestCase
     public $strOutputLayer;
     public $strDestDataSource;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
         $this->strTmpDumpFile = "DumpFile.tmp";
@@ -53,9 +53,9 @@ class OGRLayerTest2 extends TestCase
         );
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         OGR_DS_Destroy($this->hSrcDataSource);

--- a/phpunit_tests/src/tests/OGRLayerTest2.php
+++ b/phpunit_tests/src/tests/OGRLayerTest2.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRLayerTest2 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRLayerTest2 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRLayerTest3.php
+++ b/phpunit_tests/src/tests/OGRLayerTest3.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRLayerTest3 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRLayerTest3 extends TestCase
 {
     public $strPathToOutputData;
     public $strTmpDumpFile;

--- a/phpunit_tests/src/tests/OGRLayerTest3.php
+++ b/phpunit_tests/src/tests/OGRLayerTest3.php
@@ -15,15 +15,15 @@ class OGRLayerTest3 extends TestCase
     public $strOutputLayer;
     public $strDestDataSource;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
         $sourceData = test_data_path("andorra", "shp", "gis_osm_places_free_1.*");
@@ -57,9 +57,9 @@ class OGRLayerTest3 extends TestCase
         $this->assertNotNull($this->hSrcDataSource, "Could not open datasource " . $this->strPathToData);
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         OGR_DS_Destroy($this->hSrcDataSource);

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest0.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest0.php
@@ -13,17 +13,17 @@ class OGRSFDriverRegistrarTest0 extends TestCase
     public $strFilename;
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->bUpdate = false;
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         unset($this->strPathToData);

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest0.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest0.php
@@ -1,9 +1,11 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * @runTestsInSeparateProcesses
  */
-class OGRSFDriverRegistrarTest0 extends PHPUnit_Framework_TestCase
+class OGRSFDriverRegistrarTest0 extends TestCase
 {
     public $strPathToData;
     public $bUpdate;

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest1.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest1.php
@@ -1,9 +1,11 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * @runTestsInSeparateProcesses
  */
-class OGRSFDriverRegistrarTest1 extends PHPUnit_Framework_TestCase
+class OGRSFDriverRegistrarTest1 extends TestCase
 {
     public $strPathToData;
     public $bUpdate;

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest1.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest1.php
@@ -12,18 +12,18 @@ class OGRSFDriverRegistrarTest1 extends TestCase
     public $hOGRSFDriver;
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = create_temp_directory(__CLASS__);
         $this->bUpdate = false;
         $this->hOGRSFDriver = null;
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         unset($this->strPathToData);

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest2.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest2.php
@@ -1,9 +1,11 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * @runTestsInSeparateProcesses
  */
-class OGRSFDriverRegistrarTest2 extends PHPUnit_Framework_TestCase
+class OGRSFDriverRegistrarTest2 extends TestCase
 {
     public $strPathToData;
     public $bUpdate;

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest2.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest2.php
@@ -12,18 +12,18 @@ class OGRSFDriverRegistrarTest2 extends TestCase
     public $hOGRSFDriver;
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->bUpdate = false;
         $this->hOGRSFDriver = null;
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         unset($this->strPathToData);

--- a/phpunit_tests/src/tests/OGRSFDriverRegistrarTest3.php
+++ b/phpunit_tests/src/tests/OGRSFDriverRegistrarTest3.php
@@ -1,9 +1,11 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * @runTestsInSeparateProcesses
  */
-class OGRSFDriverRegistrarTest3 extends PHPUnit_Framework_TestCase
+class OGRSFDriverRegistrarTest3 extends TestCase
 {
 
     /***********************************************************************

--- a/phpunit_tests/src/tests/OGRSFDriverTest0.php
+++ b/phpunit_tests/src/tests/OGRSFDriverTest0.php
@@ -11,15 +11,15 @@ class OGRSFDriverTest0 extends TestCase
     public $hOGRSFDriver;
     public $strCapability;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         OGRRegisterAll();
     }
 
     // called before the test functions will be executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function setUp()
+    public function setUp() : void
     {
         $this->strPathToData = test_data_path("andorra", "shp");
         $this->strPathToOutputData = create_temp_directory(__CLASS__);
@@ -28,9 +28,9 @@ class OGRSFDriverTest0 extends TestCase
         $this->strCapability = ODrCCreateDataSource;
     }
     // called after the test functions are executed
-    // this function is defined in PHPUnit_Framework_TestCase and overwritten
+    // this function is defined in TestCase and overwritten
     // here
-    public function tearDown()
+    public function tearDown() : void
     {
         // delete your instance
         delete_directory($this->strPathToOutputData);

--- a/phpunit_tests/src/tests/OGRSFDriverTest0.php
+++ b/phpunit_tests/src/tests/OGRSFDriverTest0.php
@@ -1,6 +1,8 @@
 <?php
 
-class OGRSFDriverTest0 extends PHPUnit_Framework_TestCase
+use \PHPUnit\Framework\TestCase;
+
+class OGRSFDriverTest0 extends TestCase
 {
     public $strPathToData;
     public $strPathToOutputData;

--- a/phpunit_tests/src/tests/OSR_0_MemoryManagementTest0.php
+++ b/phpunit_tests/src/tests/OSR_0_MemoryManagementTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for basic memory management in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_0_MemoryManagementTest0 extends PHPUnit_Framework_TestCase
+class OSR_0_MemoryManagementTest0 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/tests/OSR_0_MemoryManagementTest0.php
+++ b/phpunit_tests/src/tests/OSR_0_MemoryManagementTest0.php
@@ -19,8 +19,7 @@ class OSR_0_MemoryManagementTest0 extends TestCase
     {
         $hRef = OSR_NewSpatialReference();
         $this->assertNotNull($hRef, "New spatial reference should not be NULL");
-        $this->assertInternalType(
-            "resource",
+        $this->assertIsResource(
             $hRef,
             "New spatial reference should be a resource"
         );
@@ -40,8 +39,7 @@ class OSR_0_MemoryManagementTest0 extends TestCase
     {
         $hRef = OSR_NewSpatialReference();
         OSR_DestroySpatialReference($hRef);
-        $this->assertInternalType(
-            "resource",
+        $this->assertIsResource(
             $hRef,
             "Destroyed spatial reference is still a resource"
         );

--- a/phpunit_tests/src/tests/OSR_0_ValidationTest0.php
+++ b/phpunit_tests/src/tests/OSR_0_ValidationTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for validation in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_0_ValidationTest0 extends PHPUnit_Framework_TestCase
+class OSR_0_ValidationTest0 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/tests/OSR_1_ImportTest0.php
+++ b/phpunit_tests/src/tests/OSR_1_ImportTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for import functions in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_1_ImportTest0 extends PHPUnit_Framework_TestCase
+class OSR_1_ImportTest0 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/tests/OSR_2_ExportTest0.php
+++ b/phpunit_tests/src/tests/OSR_2_ExportTest0.php
@@ -22,8 +22,7 @@ class OSR_2_ExportTest0 extends TestCase
         $hRef = OSR_NewSpatialReference();
         OSR_ImportFromEPSG($hRef, 4326);
         $wkt = OSR_ExportToWKT($hRef);
-        $this->assertInternalType(
-            "string",
+        $this->assertIsString(
             $wkt,
             "Successful WKT export for EPSG:4326 should be a string"
         );
@@ -62,8 +61,7 @@ class OSR_2_ExportTest0 extends TestCase
         $testFile = test_data_path('osr', 'epsg4326.wkt');
         OSR_SetFromUserInput($hRef, $testFile);
         $wkt = OSR_ExportToPrettyWKT($hRef, false);
-        $this->assertInternalType(
-            "string",
+        $this->assertIsString(
             $wkt,
             "Successful pretty WKT export for EPSG:4326 should be a string"
         );
@@ -86,8 +84,7 @@ class OSR_2_ExportTest0 extends TestCase
         $testFile = test_data_path('osr', 'epsg4326.wkt');
         OSR_SetFromUserInput($hRef, $testFile);
         $wkt = OSR_ExportToPrettyWKT($hRef, true);
-        $this->assertInternalType(
-            "string",
+        $this->assertIsString(
             $wkt,
             "Successful pretty WKT export for EPSG:4326 should be a string"
         );
@@ -125,8 +122,7 @@ class OSR_2_ExportTest0 extends TestCase
         $hRef = OSR_NewSpatialReference();
         OSR_ImportFromEPSG($hRef, 4326);
         $proj = OSR_ExportToProj4($hRef);
-        $this->assertInternalType(
-            "string",
+        $this->assertIsString(
             $proj,
             "Successful Proj4 export for EPSG:4326 should be a string"
         );

--- a/phpunit_tests/src/tests/OSR_2_ExportTest0.php
+++ b/phpunit_tests/src/tests/OSR_2_ExportTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for export in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_2_ExportTest0 extends PHPUnit_Framework_TestCase
+class OSR_2_ExportTest0 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/tests/OSR_2_ValidationTest1.php
+++ b/phpunit_tests/src/tests/OSR_2_ValidationTest1.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for successful validation in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_2_ValidationTest1 extends PHPUnit_Framework_TestCase
+class OSR_2_ValidationTest1 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/tests/OSR_3_AccessTest0.php
+++ b/phpunit_tests/src/tests/OSR_3_AccessTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for accessor functions in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_3_AccessTest0 extends PHPUnit_Framework_TestCase
+class OSR_3_AccessTest0 extends TestCase
 {
     /**
      * Test candidate EPSG:31468

--- a/phpunit_tests/src/tests/OSR_3_AccessTest0.php
+++ b/phpunit_tests/src/tests/OSR_3_AccessTest0.php
@@ -28,7 +28,7 @@ class OSR_3_AccessTest0 extends TestCase
     /**
      * @depends OSR_1_ImportTest0::testOSR_SetFromUserInput2
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         foreach (array(4326, 31468) as $epsg) {
             $var = sprintf('srs%d', $epsg);

--- a/phpunit_tests/src/tests/OSR_3_EPSGTest0.php
+++ b/phpunit_tests/src/tests/OSR_3_EPSGTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for special EPSG functions in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_3_EPSGTest0 extends PHPUnit_Framework_TestCase
+class OSR_3_EPSGTest0 extends TestCase
 {
     /**
      * Test OSR_AutoIdentifyEPSG() with success

--- a/phpunit_tests/src/tests/OSR_3_IsTest0.php
+++ b/phpunit_tests/src/tests/OSR_3_IsTest0.php
@@ -35,7 +35,7 @@ class OSR_3_IsTest0 extends TestCase
     /**
      * @depends OSR_1_ImportTest0::testOSR_ImportFromEPSG0
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         foreach (array(4326, 31468, 4328) as $epsg) {
             $var = sprintf('srs%d', $epsg);

--- a/phpunit_tests/src/tests/OSR_3_IsTest0.php
+++ b/phpunit_tests/src/tests/OSR_3_IsTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for is*-functions in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_3_IsTest0 extends PHPUnit_Framework_TestCase
+class OSR_3_IsTest0 extends TestCase
 {
     /**
      * Test candidate EPSG:31468

--- a/phpunit_tests/src/tests/OSR_3_MorphTest0.php
+++ b/phpunit_tests/src/tests/OSR_3_MorphTest0.php
@@ -1,5 +1,7 @@
 <?php
 
+use \PHPUnit\Framework\TestCase;
+
 /**
  * Tests for morph to/from ESRI functions in OSR
  *
@@ -7,7 +9,7 @@
  *
  * @copyright ©2019 DVZ Datenverarbeitungszentrum M-V GmbH
  */
-class OSR_3_MorphTest0 extends PHPUnit_Framework_TestCase
+class OSR_3_MorphTest0 extends TestCase
 {
 
     /**

--- a/phpunit_tests/src/util.php
+++ b/phpunit_tests/src/util.php
@@ -1,4 +1,6 @@
 <?php
+
+use \PHPUnit\Framework\TestCase;
 /**
  * A set of utility functions.
  *


### PR DESCRIPTION
 * Note: Removes support for running the PHPUnit tests with versions of PHP <= 7.2